### PR TITLE
Fix screen overflow issue on small screen

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,3 @@
-* {
-    border: 1px dotted red;
-}
 
 .App {
     text-align: center;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,3 +1,7 @@
+* {
+    border: 1px dotted red;
+}
+
 .App {
     text-align: center;
 }
@@ -42,4 +46,5 @@ html,
 body {
     margin: 0;
     padding: 0;
+    background-color: #242323;
 }

--- a/frontend/src/components/EditQuestion/EditQuestion.css
+++ b/frontend/src/components/EditQuestion/EditQuestion.css
@@ -1,0 +1,4 @@
+.box {
+    background-color: #2d2d2d;
+    width: 80%;
+}

--- a/frontend/src/components/EditQuestion/EditQuestion.js
+++ b/frontend/src/components/EditQuestion/EditQuestion.js
@@ -52,7 +52,7 @@ const EditQuestion = () => {
       }
     });
 
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const navigate = useNavigate();
   const handleBackClick = () => {

--- a/frontend/src/components/EditQuestion/EditQuestion.js
+++ b/frontend/src/components/EditQuestion/EditQuestion.js
@@ -52,7 +52,7 @@ const EditQuestion = () => {
       }
     });
 
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   const navigate = useNavigate();
   const handleBackClick = () => {
@@ -95,7 +95,7 @@ const EditQuestion = () => {
 
 
   return (
-    <Box bgcolor="#2d2d2d" sx={{ height: '90vh', width: '80%', borderRadius: '25px', p: 3, boxShadow: 2, border: 2 }}>
+    <Box className="box" sx={{ borderRadius: '25px', p: 3, boxShadow: 2, border: 2 }}>
       <Button variant="outlined"
         onClick={handleBackClick} startIcon={<ArrowBackIosIcon />}>
         Back

--- a/frontend/src/components/QuestionDescription/QuestionDescription.css
+++ b/frontend/src/components/QuestionDescription/QuestionDescription.css
@@ -14,5 +14,4 @@ h1 {
     text-align: center;
     padding-bottom: 0.7em;
     border-bottom: 1px solid #fff;
-    min-width: 300px;
 }

--- a/frontend/src/components/QuestionDescription/QuestionDescription.css
+++ b/frontend/src/components/QuestionDescription/QuestionDescription.css
@@ -3,10 +3,16 @@
     font: 400 1rem/1rem "Roboto", sans-serif;
 }
 
+.box {
+    background-color: #2d2d2d;
+    width: 80%;
+}
+
 .horizontal-row {}
 
 h1 {
     text-align: center;
     padding-bottom: 0.7em;
     border-bottom: 1px solid #fff;
+    min-width: 300px;
 }

--- a/frontend/src/components/QuestionDescription/QuestionDescription.js
+++ b/frontend/src/components/QuestionDescription/QuestionDescription.js
@@ -56,7 +56,7 @@ const QuestionDescription = () => {
       });
     });
   };
-  // bgcolor="#2d2d2d"
+  
   return (
     <Box className="box" sx={{ borderRadius: '25px', p: 3, boxShadow: 2, border: 2 }}>
 

--- a/frontend/src/components/QuestionDescription/QuestionDescription.js
+++ b/frontend/src/components/QuestionDescription/QuestionDescription.js
@@ -56,9 +56,9 @@ const QuestionDescription = () => {
       });
     });
   };
-
+  // bgcolor="#2d2d2d"
   return (
-    <Box bgcolor="#2d2d2d" sx={{ height: '90vh', width: '80%', borderRadius: '25px', p: 3, boxShadow: 2, border: 2 }}>
+    <Box className="box" sx={{ borderRadius: '25px', p: 3, boxShadow: 2, border: 2 }}>
 
       <div className="question-description">
         <div className="horizontal-row">
@@ -75,7 +75,7 @@ const QuestionDescription = () => {
             Edit
           </Button>
         </div>
-        <h1>{question?.title}</h1>
+        <h1 className="question-title">{question?.title}</h1>
         <h3>Complexity: {question?.complexity}</h3>
         <p>{question?.description}</p>
       </div>

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -1,8 +1,7 @@
 .landing-page {
-    background-color: #242323;
-    min-height: 100vh;
+    margin: 5%;
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 100vh;
+    height: auto;
 }


### PR DESCRIPTION
Closes #2 .

<b> Issue </b>
1. On small screen Box tag resizes independent of child elements, causing child elements to overflow.
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g32/assets/97402534/bdfd50ca-89d6-4a51-818d-ae29b1533139)
2. Background shifts up on small screens, bg-colour no longer fills page appropriately (as shown above).
  
<b> Fixes </b>
1. Set `height: auto;` in LandingPage.css
2. Remove height and width style elements in Box tags to prevent overriding.
3. Set background colour in App.css since the individual landing pages does not change this.