### PR TITLE
Add support for change password, including input checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ Or start them indvidually:
 |`/user/read`| Used to get user info | `id` or `email` |
 |`/user/update`| Used to update user info (username, password) | `id` <br> `username` or `password` |
 |`/user/delete`| Used to delete user | `id` |
+|`/user/change-password`|Used to change user password|`id` <br> `currentPassword` <br> `newPassword` <br> `confirmPassword` |

--- a/backend/server/controllers/userController.js
+++ b/backend/server/controllers/userController.js
@@ -44,10 +44,22 @@ const deleteUser = async (req, res) => {
   }
 };
 
+const changePassword = async (req, res) => {
+  try {
+    const { id, currentPassword, newPassword, confirmPassword } = req.body;
+    await userService.changeUserPassword(id, currentPassword, newPassword, confirmPassword);
+    res.json({ message: 'SUCCESS: Password changed' });
+  } catch (err) {
+    res.status(err?.status || 400)
+       .json({ error: err?.message || err });
+  }
+};
+
 module.exports = {
   createUser,
   getUserInfo,
   updateUser,
-  deleteUser, 
+  deleteUser,
+  changePassword, 
 };
   

--- a/backend/server/routes/user.js
+++ b/backend/server/routes/user.js
@@ -7,5 +7,6 @@ router.post('/create', userController.createUser);
 router.post('/read', userController.getUserInfo);
 router.post('/update', userController.updateUser);
 router.post('/delete', userController.deleteUser);
+router.post('/change-password', userController.changePassword);
 
 module.exports = router;


### PR DESCRIPTION
API path: `/user/change-password`
Expected keys: `id`, `currentPassword`, `newPassword`, `confirmPassword`
Checks made:
 - Missing input(s)
 - Same old & new password
 - New password mismatch
 - Wrong current password

Failing any checks will result in throwing error.
Otherwise, attempts to change password. Might throw internal (generic) errors.
If password change is successful, JSON message `SUCCESS: Password changed` is returned.

Closes #49.