### PR TITLE
Deconflict front and backend use of PORT 3000

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -7,7 +7,7 @@ const questionRoutes = require('./server/routes/question');
 require('dotenv').config();
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 5000;
 const MONGOCLIENT = process.env.ATLAS_URI || "";
 
 app.use(cors());

--- a/frontend/src/api/QuestionApi.js
+++ b/frontend/src/api/QuestionApi.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const rootUrl = 'http://localhost:3000/question';
+const rootUrl = 'http://localhost:5000/question';
 
 const config = {
   headers: {

--- a/frontend/src/components/QuestionDescription/QuestionDescription.js
+++ b/frontend/src/components/QuestionDescription/QuestionDescription.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 import { getQuestionDetails, deleteQuestion } from '../../api/QuestionApi.js';
-import { showValidationErrorToast, showServerErrorToast, showSuccessToast, showQuestionNotFoundErrorToast, showFailureToast } from '../../utils/toast.js';
+import { showServerErrorToast, showSuccessToast, showQuestionNotFoundErrorToast, showFailureToast } from '../../utils/toast.js';
 import { DeletionWindow } from '../ConfirmationWindow/ConfirmationWindows.js';
 import './QuestionDescription.css';
 import '../../css/Tags.css';


### PR DESCRIPTION
This PR consists of:

- Changing the backend port to 5000 (temporarily deconflict the usage of port 3000 by both front and backend)
- For subsequent iterations, we can have frontend to dynamically retrieve the backend port or through the use of .env file to set ports