### PR TITLE
Add dynamic queue creation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,8 @@
                 "mongoose": "^7.5.0",
                 "mysql2": "^3.6.1",
                 "save": "^2.9.0",
-                "socket.io": "^4.7.2"
+                "socket.io": "^4.7.2",
+                "uuid": "^9.0.1"
             },
             "devDependencies": {
                 "nodemon": "^3.0.1"
@@ -2253,6 +2254,18 @@
             "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,8 @@
         "mongoose": "^7.5.0",
         "mysql2": "^3.6.1",
         "save": "^2.9.0",
-        "socket.io": "^4.7.2"
+        "socket.io": "^4.7.2",
+        "uuid": "^9.0.1"
     },
     "devDependencies": {
         "nodemon": "^3.0.1"

--- a/backend/server.js
+++ b/backend/server.js
@@ -64,20 +64,20 @@ try {
   });
 
   io.on('connection', (socket) => {
-    socket.on('joinRoom', (room) => {
-      socket.join(room);
-      console.log(`User joined room: ${room}`);
+    socket.on('joinRoom', (data) => {
+      socket.join(data.room);
+      console.log(`${data.host} joined room: ${data.room}`);
 
       // Broadcast a message to the room when someone joins
-      io.to(room).emit('message', `User joined room: ${room}`);
+      io.to(data.room).emit('message', `${data.host} joined room: ${data.room}`);
     });
 
-    socket.on('leaveRoom', (room) => {
-      socket.leave(room); // Leave the specified room
-      console.log(`User left room: ${room}`);
+    socket.on('leaveRoom', (data) => {
+      socket.leave(data.room); // Leave the specified room
+      console.log(`${data.host} joined room: ${data.room}`);
 
       // Broadcast a message to the room when someone leaves
-      io.to(room).emit('message', `User left room: ${room}`);
+      io.to(data.room).emit('message', `${data.host} joined room: ${data.room}`);
     });
 
     // Handle chat messages

--- a/backend/server/controllers/queueController.js
+++ b/backend/server/controllers/queueController.js
@@ -2,8 +2,8 @@ const queueService = require('../services/queueService');
 
 const joinQueue = async (req, res) => {
   try {
-    const { id, complexityType } = req.body;
-    const response = await queueService.joinQueue(id, complexityType);
+    const { id, queueName } = req.body;
+    const response = await queueService.joinQueue(id, queueName);
     res.json({ message: 'Joined queue successfully', response });
   } catch (err) {
     res
@@ -14,8 +14,8 @@ const joinQueue = async (req, res) => {
 
 const exitQueue = async (req, res) => {
   try {
-    const { id, complexityType } = req.body;
-    await queueService.exitQueue(id, complexityType);
+    const { id, queueName } = req.body;
+    await queueService.exitQueue(id, queueName);
     res.json({ message: 'Exited queue successfully' });
   } catch (err) {
     res

--- a/backend/server/services/queueService.js
+++ b/backend/server/services/queueService.js
@@ -1,73 +1,83 @@
 const amqp = require('amqplib');
+const { v4: uuidv4 } = require('uuid');
 const url = 'amqp://localhost';
 
+// Generate a unique id
 const generateUuid = () => {
-  return "id" + Math.random().toString(16).slice(2);
+  return uuidv4();
 };
 
-const joinQueue = async (id, complexityType) => {
-  const responseQueue = complexityType + 'ResponseQueue';
-
+/*
+  Uses a request-reply messaging pattern.
+  The requester (client) sends a request to requestQueue (to join the queue).
+  The responder (server) consumes and process the request, and sends a response to responseQueue.
+  The requester (client) consumes the response to get the result.
+*/
+const joinQueue = async (id, queueName) => {
   const connection = await amqp.connect(url);
   const channel = await connection.createChannel();
 
-  await channel.assertQueue(complexityType, { durable: false });
-  await channel.assertQueue(responseQueue, { durable: false });
+  const requestQueue = queueName;
+  const responseQueue = queueName + 'Response';
 
-  // Create a unique Id for the request
+  await channel.assertQueue('commonQueue', { durable: false });
+  await channel.assertQueue(requestQueue, { durable: false, autoDelete: true });
+  await channel.assertQueue(responseQueue, { durable: false, autoDelete: true });
+
+  // Send the names of the request and response queues to the common queue for the server to create the queues
+  channel.sendToQueue('commonQueue', Buffer.from(JSON.stringify({
+    requestQueue: requestQueue,
+    responseQueue: responseQueue
+  })));
+
   const correlationId = generateUuid();
-
-  // Send the request to the queue
-  channel.sendToQueue(complexityType, Buffer.from(JSON.stringify({
-    complexityType: complexityType,
+  const message = {
     id: id,
     replyTo: responseQueue,
     correlationId: correlationId,
     timestamp: Date.now(),
     isExit: false
-  })));
+  };
 
-  // Variable to check if the connection is closed
-  var isClosed = false;
+  // Send the message to the request queue with the queue name as a property
+  channel.sendToQueue(requestQueue, Buffer.from(JSON.stringify(message)), {
+    queueName: queueName
+  });
 
+  // Used to check if the connection is closed
   return new Promise((resolve, reject) => {
-    // Wait for the response with matching correlation ID
+    // Waits for the response with matching correlation ID
     channel.consume(responseQueue, (response) => {
       if (response.properties.correlationId === correlationId) {
-
         const responseBody = JSON.parse(response.content.toString());
         resolve(responseBody);
-
         channel.ack(response);
 
         // Close the connection
         isClosed = true;
         channel.close();
         connection.close();
-
       }
     }, { noAck: false });
   });
 };
 
-const exitQueue = async (id, complexityType) => {
+// Send an exit request to the request queue
+const exitQueue = async (id, queueName) => {
   const connection = await amqp.connect(url);
   const channel = await connection.createChannel();
 
-  await channel.assertQueue(complexityType, { durable: false });
+  const requestQueue = queueName;
+  await channel.assertQueue(requestQueue, { durable: false, autoDelete: true });
 
-  channel.sendToQueue(complexityType, Buffer.from(JSON.stringify({
-    complexityType: complexityType,
+  const message = {
     id: id,
     isExit: true
-  })));
+  };
 
-  setTimeout(() => {
-    channel.close();
-    connection.close();
-  }, 500);
+  // Send the message to the request queue
+  channel.sendToQueue(requestQueue, Buffer.from(JSON.stringify(message)));
 };
-
 
 module.exports = {
   joinQueue,

--- a/frontend/src/api/QueueApi.js
+++ b/frontend/src/api/QueueApi.js
@@ -9,11 +9,11 @@ const config = {
   }
 };
 
-export const joinQueue = async (user, complexityType) => {
+export const joinQueue = async (user, queueName) => {
   try {
     const data = {
       id: user.id,
-      complexityType: complexityType
+      queueName: queueName
     };
     return await axios.post(rootUrl + "/join", data, config);
   } catch (err) {
@@ -24,11 +24,11 @@ export const joinQueue = async (user, complexityType) => {
   }
 };
 
-export const exitQueue = async (user, complexityType) => {
+export const exitQueue = async (user, queueName) => {
   try {
     const data = {
       id: user.id,
-      complexityType: complexityType
+      queueName: queueName
     };
     return await axios.post(rootUrl + "/exit", data, config);
   } catch (err) {

--- a/frontend/src/components/MatchMaking/MatchingModal.js
+++ b/frontend/src/components/MatchMaking/MatchingModal.js
@@ -9,7 +9,8 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 const MatchingModal = ({ isOpen, onClose }) => {
 
   const [isFindingMatch, setIsFindingMatch] = useState(false);
-  const [complexityValue, setComplexityValue] = useState('Easy');
+  const [complexity, setComplexity] = useState('Easy');
+  const [programmingLanguage, setProgrammingLanguage] = useState('');
 
   const storedUser = JSON.parse(localStorage.getItem('user'));
   const navigate = useNavigate();
@@ -21,7 +22,8 @@ const MatchingModal = ({ isOpen, onClose }) => {
 
     const handleExitTab = async () => {
       if (isFindingMatch) {
-        await exitQueue(storedUser, complexityValue);
+        const queueName = complexity + programmingLanguage;
+        await exitQueue(storedUser, queueName);
       }
     };
 
@@ -32,8 +34,12 @@ const MatchingModal = ({ isOpen, onClose }) => {
     };
   }, [navigate, storedUser]);
 
-  const handleComplexityValueChange = (event) => {
-    setComplexityValue(event.target.value);
+  const handleComplexityChange = (event) => {
+    setComplexity(event.target.value);
+  };
+
+  const handleLanguageChange = (event) => {
+    setProgrammingLanguage(event.target.value);
   };
 
   const handleMatchingToggle = async () => {
@@ -42,7 +48,8 @@ const MatchingModal = ({ isOpen, onClose }) => {
 
   const handleClosingModal = () => {
     if (isFindingMatch) {
-      exitQueue(storedUser, complexityValue);
+      const queueName = complexity + programmingLanguage;
+      exitQueue(storedUser, queueName);
     }
     onClose();
     setIsFindingMatch(false);
@@ -60,19 +67,32 @@ const MatchingModal = ({ isOpen, onClose }) => {
             </div>
             {isFindingMatch ? (
               <div className="modal-body">
-                <Queue user={storedUser} complexity={complexityValue} onCancel={handleMatchingToggle} />
+                <Queue
+                  user={storedUser}
+                  queueName={complexity + programmingLanguage}
+                  onCancel={handleMatchingToggle}
+                />
               </div>
             ) : (
               <div>
                 <div className="modal-body">
                   <form className='create-question-form needs-validation' >
                     <div className='form-floating mb-3'>
-                      <select className='form-select mb-3' id='matchingQuestitonComplexity' defaultValue={complexityValue} onChange={handleComplexityValueChange} >
+                      <select className='form-select mb-3' id='matchingQuestitonComplexity' defaultValue={complexity} onChange={handleComplexityChange} >
                         <option value='Easy'>Easy</option>
                         <option value='Medium'>Medium</option>
                         <option value='Hard'>Hard</option>
                       </select>
                       <label htmlFor='matchingQuestitonComplexity'>Complexity</label>
+                    </div>
+                    <div className='form-floating mb-3'>
+                      <select className='form-select mb-3' id='matchingQuestitonLanguage' defaultValue={programmingLanguage} onChange={handleLanguageChange} >
+                        <option value=''>Select a Programming Language</option>
+                        <option value='Python'>Python</option>
+                        <option value='Java'>Java</option>
+                        <option value='C++'>C++</option>
+                      </select>
+                      <label htmlFor='matchingQuestitonLanguage'>Programming Language</label>
                     </div>
                   </form>
                 </div>

--- a/frontend/src/components/MatchMaking/Queue.js
+++ b/frontend/src/components/MatchMaking/Queue.js
@@ -5,7 +5,7 @@ import { joinQueue, exitQueue } from '../../api/QueueApi.js';
 import { errorHandler } from '../../utils/errors.js';
 import { showFailureToast } from '../../utils/toast.js';
 
-const Queue = ({ user, complexity, onCancel }) => {
+const Queue = ({ user, queueName, onCancel }) => {
 
   const [status, setStatus] = useState({});
   const [isLoading, setIsLoading] = useState(true);
@@ -15,7 +15,7 @@ const Queue = ({ user, complexity, onCancel }) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const reply = await joinQueue(user, complexity);
+        const reply = await joinQueue(user, queueName);
         setStatus(reply.data.response.message);
         setIsLoading(false);
 
@@ -23,14 +23,16 @@ const Queue = ({ user, complexity, onCancel }) => {
         const isMatch = reply.data.response.isMatch;
         if (isMatch) {
           const roomId = reply.data.response.roomId;
-          navigate('/collaboration', { state: { roomId } });
+          const hostId = reply.data.response.hostId;
+          const matchedHostId = reply.data.response.matchedHostId;
+          navigate('/collaboration', { state: { roomId, hostId, matchedHostId } });
         }
       } catch (error) {
         errorHandler(error);
       }
     };
     fetchData();
-  }, [user, complexity, navigate]);
+  }, [user, queueName, navigate]);
 
   useEffect(() => {
     setTimeout(() => {
@@ -46,7 +48,7 @@ const Queue = ({ user, complexity, onCancel }) => {
 
   const handleCancelClick = () => {
     try {
-      exitQueue(user, complexity);
+      exitQueue(user, queueName);
       onCancel();
     } catch (error) {
       errorHandler(error);

--- a/frontend/src/pages/Collaboration/Collaboration.js
+++ b/frontend/src/pages/Collaboration/Collaboration.js
@@ -6,7 +6,10 @@ const Collaboration = () => {
 
   const location = useLocation();
   const navigate = useNavigate();
+
   const roomId = location.state?.roomId;
+  const hostId = location.state?.hostId;
+  const matchedHostId = location.state?.matchedHostId;
 
   const [message, setMessage] = useState('');
   const [messages, setMessages] = useState([]);
@@ -14,12 +17,8 @@ const Collaboration = () => {
   const socket = io('http://localhost:3002');
 
   useEffect(() => {
-    // Replace with your Socket.io server URL
-
-    const roomName = roomId
-
     // Join the Socket.io room when the component mounts
-    socket.emit('joinRoom', roomName);
+    socket.emit('joinRoom', { room: roomId, host: hostId });
 
     // Listen for incoming messages from the server
 
@@ -37,13 +36,14 @@ const Collaboration = () => {
   };
 
   const handleLeaveRoom = () => {
-    socket.emit('leaveRoom', roomId);
-    navigate('/match-making');
+    socket.emit('leaveRoom', { room: roomId, host: hostId });
+    navigate('/landing');
   };
 
   return (
     <div>
       <h1>RoomID: {roomId}</h1>
+      <h2>You have been match with Host {matchedHostId}</h2>
       <div>
         <ul>
           {messages.map((msg, index) => (


### PR DESCRIPTION
This PR consists of:

- Changing how matchings queues are created by using a common queue to instantiate queues
- This allows for idle queues to be deleted
- As well as only requiring to update frontend whenever we wish to increase the amount of matching criteria, instead of manually adding queues on the backend