### PR TITLE
Fix bug where a user can match with themselves

### DIFF
--- a/backend/server/controllers/queueController.js
+++ b/backend/server/controllers/queueController.js
@@ -2,8 +2,8 @@ const queueService = require('../services/queueService');
 
 const joinQueue = async (req, res) => {
   try {
-    const { id, queueName } = req.body;
-    const response = await queueService.joinQueue(id, queueName);
+    const { id, queueName, sessionID } = req.body;
+    const response = await queueService.joinQueue(id, queueName, sessionID);
     res.json({ message: 'Joined queue successfully', response });
   } catch (err) {
     res
@@ -14,8 +14,8 @@ const joinQueue = async (req, res) => {
 
 const exitQueue = async (req, res) => {
   try {
-    const { id, queueName } = req.body;
-    await queueService.exitQueue(id, queueName);
+    const { id, queueName, sessionID } = req.body;
+    await queueService.exitQueue(id, queueName, sessionID);
     res.json({ message: 'Exited queue successfully' });
   } catch (err) {
     res

--- a/backend/server/services/queueService.js
+++ b/backend/server/services/queueService.js
@@ -13,7 +13,7 @@ const generateUuid = () => {
   The responder (server) consumes and process the request, and sends a response to responseQueue.
   The requester (client) consumes the response to get the result.
 */
-const joinQueue = async (id, queueName) => {
+const joinQueue = async (id, queueName, sessionID) => {
   const connection = await amqp.connect(url);
   const channel = await connection.createChannel();
 
@@ -31,12 +31,14 @@ const joinQueue = async (id, queueName) => {
   })));
 
   const correlationId = generateUuid();
+
   const message = {
     id: id,
     replyTo: responseQueue,
     correlationId: correlationId,
     timestamp: Date.now(),
-    isExit: false
+    isExit: false,
+    sessionID: sessionID
   };
 
   // Send the message to the request queue with the queue name as a property
@@ -63,7 +65,7 @@ const joinQueue = async (id, queueName) => {
 };
 
 // Send an exit request to the request queue
-const exitQueue = async (id, queueName) => {
+const exitQueue = async (id, queueName, sessionID) => {
   const connection = await amqp.connect(url);
   const channel = await connection.createChannel();
 
@@ -72,7 +74,8 @@ const exitQueue = async (id, queueName) => {
 
   const message = {
     id: id,
-    isExit: true
+    isExit: true,
+    sessionID: sessionID
   };
 
   // Send the message to the request queue

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
                 "react-tagsinput": "^3.20.3",
                 "react-toastify": "^9.1.3",
                 "socket.io-client": "^4.7.2",
+                "uuidv4": "^6.2.13",
                 "web-vitals": "^2.1.4"
             }
         },
@@ -5827,6 +5828,11 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
             "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+        },
+        "node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
         },
         "node_modules/@types/warning": {
             "version": "3.0.0",
@@ -17677,6 +17683,15 @@
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/uuidv4": {
+            "version": "6.2.13",
+            "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+            "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+            "dependencies": {
+                "@types/uuid": "8.3.4",
+                "uuid": "8.3.2"
             }
         },
         "node_modules/v8-to-istanbul": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
         "react-tagsinput": "^3.20.3",
         "react-toastify": "^9.1.3",
         "socket.io-client": "^4.7.2",
+        "uuidv4": "^6.2.13",
         "web-vitals": "^2.1.4"
     },
     "scripts": {

--- a/frontend/src/api/QueueApi.js
+++ b/frontend/src/api/QueueApi.js
@@ -9,11 +9,12 @@ const config = {
   }
 };
 
-export const joinQueue = async (user, queueName) => {
+export const joinQueue = async (user, queueName, sessionID) => {
   try {
     const data = {
       id: user.id,
-      queueName: queueName
+      queueName: queueName,
+      sessionID: sessionID
     };
     return await axios.post(rootUrl + "/join", data, config);
   } catch (err) {
@@ -24,11 +25,12 @@ export const joinQueue = async (user, queueName) => {
   }
 };
 
-export const exitQueue = async (user, queueName) => {
+export const exitQueue = async (user, queueName, sessionID) => {
   try {
     const data = {
       id: user.id,
-      queueName: queueName
+      queueName: queueName,
+      sessionID: sessionID
     };
     return await axios.post(rootUrl + "/exit", data, config);
   } catch (err) {

--- a/frontend/src/components/MatchMaking/MatchingModal.js
+++ b/frontend/src/components/MatchMaking/MatchingModal.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 import { exitQueue } from '../../api/QueueApi.js';
 import Queue from './Queue';
 import '../../css/Modal.css'
@@ -11,6 +12,7 @@ const MatchingModal = ({ isOpen, onClose }) => {
   const [isFindingMatch, setIsFindingMatch] = useState(false);
   const [complexity, setComplexity] = useState('Easy');
   const [programmingLanguage, setProgrammingLanguage] = useState('');
+  const [sessionID, setSessionID] = useState('');
 
   const storedUser = JSON.parse(localStorage.getItem('user'));
   const navigate = useNavigate();
@@ -46,13 +48,14 @@ const MatchingModal = ({ isOpen, onClose }) => {
   };
 
   const handleMatchingToggle = async () => {
+    setSessionID(uuidv4);
     setIsFindingMatch(!isFindingMatch);
   };
 
   const handleClosingModal = () => {
     if (isFindingMatch) {
       const queueName = complexity + programmingLanguage;
-      exitQueue(storedUser, queueName);
+      exitQueue(storedUser, queueName, sessionID);
     }
     onClose();
     setIsFindingMatch(false);
@@ -74,6 +77,7 @@ const MatchingModal = ({ isOpen, onClose }) => {
                   user={storedUser}
                   queueName={complexity + programmingLanguage}
                   onCancel={handleMatchingToggle}
+                  sessionID={sessionID}
                 />
               </div>
             ) : (

--- a/frontend/src/components/MatchMaking/Queue.js
+++ b/frontend/src/components/MatchMaking/Queue.js
@@ -5,7 +5,7 @@ import { joinQueue, exitQueue } from '../../api/QueueApi.js';
 import { errorHandler } from '../../utils/errors.js';
 import { showFailureToast } from '../../utils/toast.js';
 
-const Queue = ({ user, queueName, onCancel }) => {
+const Queue = ({ user, queueName, onCancel, sessionID }) => {
 
   const [status, setStatus] = useState({});
   const [isLoading, setIsLoading] = useState(true);
@@ -15,7 +15,7 @@ const Queue = ({ user, queueName, onCancel }) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const reply = await joinQueue(user, queueName);
+        const reply = await joinQueue(user, queueName, sessionID);
         setStatus(reply.data.response.message);
         setIsLoading(false);
 
@@ -48,16 +48,13 @@ const Queue = ({ user, queueName, onCancel }) => {
 
   const handleCancelClick = () => {
     try {
-      exitQueue(user, queueName);
+      exitQueue(user, queueName, sessionID);
       onCancel();
     } catch (error) {
       errorHandler(error);
     }
   };
 
-  const handleBackClick = () => {
-    onCancel();
-  };
 
   return isLoading ? (
     <div className='container'>
@@ -70,7 +67,7 @@ const Queue = ({ user, queueName, onCancel }) => {
     <div className='container'>
       <div className='row text-center'>
         <p>{status}</p>
-        <button className='btn btn-secondary' onClick={handleBackClick} >Back</button>
+        <button className='btn btn-secondary' onClick={handleCancelClick} >Back</button>
       </div>
     </div>
   );


### PR DESCRIPTION
If a user logs in with the same account in multiple tabs and tries to match make, the system will update his old queue with the new one and informs the user that they have opened multiple tabs.

Updated backend exitQueue to exit based on sessionID instead of userID, or else queue in the new tab will be exited when the old tab exits.

![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g32/assets/63772723/59fb1382-f1a0-464a-9ff4-5a5f34202956)

Closes #94 