### PR TITLE
Update readme + install-all to include dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ For development, you may also want to install:
 ## Setup environment variables
 
 1. Enter the following command
-```cp template.env .env```
+   ```
+   cp template.env .env
+   ```
+
 1. Open `.env` file
 1. Enter root password (previously configured when installing MySQL)  
    Example: if your root password is "password1234", 
@@ -30,22 +33,22 @@ For development, you may also want to install:
 
 ## Install NodeJS packages
 
-```
-npm run install-all
-```
+```npm run install-all```
 
 # Start Application
 
 Start local MySQL Server (Windows Service), if necessary.
 
-Start all services by: 
-```
-npm run start-all
+Start all services by:
 
 ```
+npm run start-all
+```
+
 Or start them indvidually:  
-- Frontend: `cd frontend && npm start`  
-- Backend: `cd backend && npm start`  
+- Frontend: `npm run start:frontend`
+- Backend: `npm run start:backend`
+
 
 # Developer Notes
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
         "npm-run-all": "^4.1.5"
     },
     "scripts": {
-        "install-all": "npm-run-all -p install:*",
+        "install-all": "npm install && npm-run-all -p install:*",
         "install:backend": "cd backend && npm install",
         "install:frontend": "cd frontend && npm install",
-
         "start-all": "npm-run-all -p start:*",
         "start:backend": "cd backend && npm start",
         "start:frontend": "cd frontend && npm start"


### PR DESCRIPTION
npm run `install-all` command will automatically install its own dependency.
No longer require an external `npm install npm-run-all` before running `install-all`.