### PR TITLE
Add additional AuthApi for checking maintainers

### DIFF
--- a/Auth/server/controllers/authController.js
+++ b/Auth/server/controllers/authController.js
@@ -48,7 +48,39 @@ const authorize = async (req, res) => {
       // decodedJwtToken contains { userId, isMaintainer, iat, exp }
       isMaintainer = decodedJwtToken['isMaintainer'];
 
-      // TODO: Either create a new api or change the message sent
+      res.json({ message: 'User is authorized' });
+    });
+  } catch (err) {
+    // throw Object.assign(new Error('Incorrect password'), { status: 401 });
+    res.status(err?.status || 500).json({ error: err?.message || err });
+  }
+};
+
+const authorizeMaintainer = async (req, res) => {
+  try {
+    let isMaintainer = null;
+
+    // Extract the token from the Authorization header
+    const authHeader = req.headers['authorization'];
+    const token = authHeader && authHeader.split(' ')[1];
+
+    // No JWT token found
+    if (token == null) {
+      return res.status(401).json({ error: 'No JWT token found' });
+    }
+
+    // Verify and decode jwtToken
+    jwt.verify(token, env.JWT_SECRET_KEY, (err, decodedJwtToken) => {
+      if (err) {
+        return res.status(401).json({ error: 'Invalid JWT token' });
+      }
+
+      // decodedJwtToken contains { userId, isMaintainer, iat, exp }
+      isMaintainer = decodedJwtToken['isMaintainer'];
+
+      if (!isMaintainer) {
+        return res.status(401).json({ error: 'Not Maintainer' });
+      }
 
       res.json({ message: 'User is authorized' });
     });
@@ -58,19 +90,9 @@ const authorize = async (req, res) => {
   }
 };
 
-// const authenticate = async (req, res) => {
-//   try {
-//     const { id, curPassword } = req.body;
-//     const authRes = await authService.authenticate(id, curPassword);
-//     return authRes;
-//   } catch (error) {
-//     res.status(err?.status || 500).json({ error: err?.message || err });
-//   }
-// };
-
 module.exports = {
   login,
   signup,
   authorize,
-  // authenticate,
+  authorizeMaintainer,
 };

--- a/Auth/server/routes/auth.js
+++ b/Auth/server/routes/auth.js
@@ -6,6 +6,6 @@ const authController = require('../controllers/authController.js');
 router.post('/login', authController.login);
 router.post('/signup', authController.signup);
 router.get('/authorize', authController.authorize);
-// router.post('/authenticate', authController.authenticate);
+router.get('/authorizeMaintainer', authController.authorizeMaintainer);
 
 module.exports = router;

--- a/Auth/server/services/AuthService.js
+++ b/Auth/server/services/AuthService.js
@@ -10,6 +10,12 @@ const loginUser = async (email, password) => {
       throw Object.assign(new Error('Missing inputs'), { status: 400 });
     }
 
+    // Check if email is valid
+    var emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+    if (!emailRegex.test(email)) {
+      throw Object.assign(new Error('Invalid email'), { status: 400 });
+    }
+
     // Check if a user with the given email exists
     await authDatabase.findByEmail(email).then((info) => (userInfo = info));
     if (!userInfo) {

--- a/backend/server/api/AuthApi.js
+++ b/backend/server/api/AuthApi.js
@@ -22,25 +22,26 @@ const authorize = async (token) => {
   }
 };
 
-// const authenticate = async (userData) => {
-//   try {
-//     return await axios.post(authRootUrl + '/authenticate',
-//       userData,
-//       {
-//         headers: {
-//           'Content-Type': 'application/json',
-//         },
-//       }
-//     );
-//   } catch (err) {
-//     if (err.code === 'ERR_NETWORK') {
-//       throw Object.assign(new Error(err.code), { response: { status: 408 }, message: 'Network Error' });
-//     }
-//     throw err;
-//   }
-// };
+const authorizeMaintainer = async (token) => {
+  try {
+    return await axios.get(authRootUrl + '/authorizeMaintainer', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + token,
+      },
+    });
+  } catch (err) {
+    if (err.code === 'ERR_NETWORK') {
+      throw Object.assign(new Error(err.code), {
+        response: { status: 408 },
+        message: 'Network Error',
+      });
+    }
+    throw err;
+  }
+};
 
 module.exports = {
-  // authenticate,
   authorize,
+  authorizeMaintainer,
 };

--- a/backend/server/middleware.js
+++ b/backend/server/middleware.js
@@ -16,6 +16,23 @@ const checkToken = async (req, res, next) => {
   }
 };
 
+const checkTokenMaintainer = async (req, res, next) => {
+  // Extract the token from the Authorization header
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  
+  // Check if user has the right permissions (with auth api)
+  try {
+    await authApi.authorizeMaintainer(token);
+    next();
+  } catch (err) {
+    res
+      .status(err?.response?.status || 500)
+      .json({ error: err?.response?.data?.error || err });
+  }
+};
+
 module.exports = {
   checkToken,
+  checkTokenMaintainer,
 };

--- a/backend/server/routes/question.js
+++ b/backend/server/routes/question.js
@@ -4,17 +4,17 @@ const router = express.Router();
 const questionController = require('../../../backend/server/controllers/questionController.js');
 const middleware = require('../middleware.js');
 
-router.post('/create', middleware.checkToken, questionController.create);
+router.post('/create', middleware.checkTokenMaintainer, questionController.create);
 router.get('/getAll', middleware.checkToken, questionController.getAll);
 router.get(
   '/getQuestionDetails',
   middleware.checkToken,
   questionController.getQuestionDetails
 );
-router.post('/edit', middleware.checkToken, questionController.edit);
+router.post('/edit', middleware.checkTokenMaintainer, questionController.edit);
 router.delete(
   '/delete',
-  middleware.checkToken,
+  middleware.checkTokenMaintainer,
   questionController.deleteQuestion
 );
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
                 "datatables.net": "^1.13.6",
                 "datatables.net-bs5": "^1.13.6",
                 "dompurify": "^3.0.5",
+                "dotenv": "^16.3.1",
                 "env-cmd": "^10.1.0",
                 "jquery": "^3.7.1",
                 "js-cookie": "^3.0.5",
@@ -8249,6 +8250,17 @@
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.3.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/motdotla/dotenv?sponsor=1"
             }
         },
         "node_modules/dotenv-expand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
         "datatables.net": "^1.13.6",
         "datatables.net-bs5": "^1.13.6",
         "dompurify": "^3.0.5",
+        "dotenv": "^16.3.1",
         "env-cmd": "^10.1.0",
         "jquery": "^3.7.1",
         "js-cookie": "^3.0.5",


### PR DESCRIPTION
Updates

1. Added `checkTokenMaintainer` in AuthApi.
2. Updated the routes to handle maintainer checking.
3. Remove commented `Authenticate` function.

Possible improvements from here:
- Currently there are 2 separate routes for nonMaintainer and Maintainer, can possibly be abstracted to reduce redundancy.