### PR TITLE
Add Nginx as API Gateway through reverse proxy

### DIFF
--- a/Collaboration/src/CollaborationServer.js
+++ b/Collaboration/src/CollaborationServer.js
@@ -12,8 +12,6 @@ try {
     env.REACT_APP_HOST, // Run via Nginx
   ];
 
-  console.log('Allowed origins: ', allowedOrigins);
-
   const io = socketIo(httpServer, {
     cors: {
       origin: allowedOrigins,

--- a/Collaboration/src/CollaborationServer.js
+++ b/Collaboration/src/CollaborationServer.js
@@ -6,9 +6,17 @@ console.log('Starting CollaborationServer...');
 
 try {
   const httpServer = http.createServer();
+
+  const allowedOrigins = [
+    env.WEB_URL, // Run locally
+    env.REACT_APP_HOST, // Run via Nginx
+  ];
+
+  console.log('Allowed origins: ', allowedOrigins);
+
   const io = socketIo(httpServer, {
     cors: {
-      origin: env.WEB_URL,
+      origin: allowedOrigins,
       methods: ['GET', 'POST'],
     },
   });

--- a/Collaboration/src/loadEnvironment.js
+++ b/Collaboration/src/loadEnvironment.js
@@ -11,4 +11,5 @@ const WEB_URL = REACT_APP_HOST + ':' + WEB_PORT;
 module.exports = {
   COLLAB_PORT,
   WEB_URL,
+  REACT_APP_HOST,
 };

--- a/Match/src/MatchServer.js
+++ b/Match/src/MatchServer.js
@@ -44,7 +44,7 @@ const rabbitMQserver = async () => {
   const channel = await connection.createChannel();
   await channel.assertQueue('commonQueue', { durable: false });
 
-  console.log(`Matchserver is using RabbitMQ server: ${env.RABBITMQ_URL}`)
+  console.log(`Matchserver is connected to RabbitMQ server: ${env.RABBITMQ_URL}`)
 
   // Consume from the common queue
   channel.consume('commonQueue', async (message) => {

--- a/Match/src/helpers/callsToAuth.js
+++ b/Match/src/helpers/callsToAuth.js
@@ -2,10 +2,13 @@ const axios = require('axios');
 const env = require('../loadEnvironment.js');
 
 const authRootUrl = env.AUTH_URL + '/auth';
+const axiosInstance = axios.create({
+  baseURL: authRootUrl,
+});
 
 const authorize = async (token) => {
   try {
-    return await axios.get(authRootUrl + '/authorize', {
+    return await axiosInstance.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/Match/src/helpers/callsToAuth.js
+++ b/Match/src/helpers/callsToAuth.js
@@ -1,14 +1,13 @@
 const axios = require('axios');
 const env = require('../loadEnvironment.js');
 
-const authRootUrl = env.AUTH_URL + '/auth';
-const axiosInstance = axios.create({
-  baseURL: authRootUrl,
+const axiosAuth = axios.create({
+  baseURL: env.AUTH_URL + '/auth',
 });
 
 const authorize = async (token) => {
   try {
-    return await axiosInstance.get('/authorize', {
+    return await axiosAuth.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/Nginx/Dockerfile
+++ b/Nginx/Dockerfile
@@ -1,0 +1,13 @@
+# Define the image you want to build from.
+# In this case, we are using the latest version of Nginx.
+FROM nginx:latest
+
+# Copy the nginx configuration file to the image.
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Expose ports so they can be mapped by Docker daemon.
+# Should expose ${NGINX_PORT}
+EXPOSE 80
+
+# Define the command to run your app using CMD which defines your runtime.
+CMD ["nginx", "-g", "daemon off;"]

--- a/Nginx/nginx.conf
+++ b/Nginx/nginx.conf
@@ -1,0 +1,61 @@
+events {
+    worker_connections  1024;
+}
+
+http {
+
+    upstream frontend {
+        server svc-web-ui:3000;
+    }
+
+    upstream user-server {
+        server svc-user:4001;
+    }
+
+    upstream auth-server {
+        server svc-auth:5001;
+    }
+
+    upstream question-server {
+        server svc-question:6001;
+    }
+
+    upstream match-server {
+        server svc-match:7001;
+    }
+
+    upstream collab-server {
+        server svc-collab:8001;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_pass http://frontend;
+            
+        }
+
+        location /user {
+            proxy_pass http://user-server;
+        }
+
+        location /auth {
+            proxy_pass http://auth-server;
+        }
+
+        location /question {
+            proxy_pass http://question-server;
+        }
+
+        location /queue {
+            proxy_pass http://match-server;
+        }
+
+        # React router navigation
+        location /collaboration {
+            proxy_pass http://collab-server;
+        }
+    }
+}

--- a/Nginx/nginx.conf
+++ b/Nginx/nginx.conf
@@ -1,9 +1,8 @@
 events {
-    worker_connections  1024;
+    worker_connections 1024;
 }
 
 http {
-
     upstream frontend {
         server svc-web-ui:3000;
     }
@@ -34,7 +33,13 @@ http {
 
         location / {
             proxy_pass http://frontend;
-            
+        }
+
+        location /ws {
+            proxy_pass http://frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
         }
 
         location /user {
@@ -53,7 +58,6 @@ http {
             proxy_pass http://match-server;
         }
 
-        # React router navigation
         location /collaboration {
             proxy_pass http://collab-server;
         }

--- a/Nginx/nginx.conf
+++ b/Nginx/nginx.conf
@@ -31,17 +31,6 @@ http {
         listen 80;
         server_name localhost;
 
-        location / {
-            proxy_pass http://frontend;
-        }
-
-        location /ws {
-            proxy_pass http://frontend;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "Upgrade";
-        }
-
         location /user {
             proxy_pass http://user-server;
         }
@@ -60,6 +49,28 @@ http {
 
         location /collaboration {
             proxy_pass http://collab-server;
+        }
+
+        location /user-profile {
+            proxy_pass http://frontend;
+        }
+
+        location /users-management {
+            proxy_pass http://frontend;
+        }
+
+        location /ws {
+            proxy_pass http://frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+        }
+
+        location / {
+            proxy_pass http://frontend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
         }
     }
 }

--- a/Question/src/helpers/callsToAuth.js
+++ b/Question/src/helpers/callsToAuth.js
@@ -1,14 +1,13 @@
 const axios = require('axios');
 const env = require('../loadEnvironment.js');
 
-const authRootUrl = env.AUTH_URL + '/auth';
-const axiosInstance = axios.create({
-  baseURL: authRootUrl,
+const axiosAuth = axios.create({
+  baseURL: env.AUTH_URL + '/auth',
 });
 
 const authorize = async (token) => {
   try {
-    return await axiosInstance.get('/authorize', {
+    return await axiosAuth.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,
@@ -27,7 +26,7 @@ const authorize = async (token) => {
 
 const authorizeMaintainer = async (token) => {
   try {
-    return await axiosInstance.get('/authorizeMaintainer', {
+    return await axiosAuth.get('/authorizeMaintainer', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/Question/src/helpers/callsToAuth.js
+++ b/Question/src/helpers/callsToAuth.js
@@ -2,10 +2,13 @@ const axios = require('axios');
 const env = require('../loadEnvironment.js');
 
 const authRootUrl = env.AUTH_URL + '/auth';
+const axiosInstance = axios.create({
+  baseURL: authRootUrl,
+});
 
 const authorize = async (token) => {
   try {
-    return await axios.get(authRootUrl + '/authorize', {
+    return await axiosInstance.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,
@@ -24,7 +27,7 @@ const authorize = async (token) => {
 
 const authorizeMaintainer = async (token) => {
   try {
-    return await axios.get(authRootUrl + '/authorizeMaintainer', {
+    return await axiosInstance.get('/authorizeMaintainer', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/User/src/helpers/callsToAuth.js
+++ b/User/src/helpers/callsToAuth.js
@@ -1,14 +1,13 @@
 const axios = require('axios');
 const env = require('../loadEnvironment.js');
 
-const authRootUrl = env.AUTH_URL + '/auth';
-const axiosInstance = axios.create({
-  baseURL: authRootUrl,
+const axiosAuth = axios.create({
+  baseURL: env.AUTH_URL + '/auth',
 });
 
 const getToken = async (userInfo) => {
   try {
-    return await axiosInstance.post('/generate', userInfo, {
+    return await axiosAuth.post('/generate', userInfo, {
       headers: {
         'Content-Type': 'application/json',
       },
@@ -26,7 +25,7 @@ const getToken = async (userInfo) => {
 
 const authorize = async (token) => {
   try {
-    return await axiosInstance.get('/authorize', {
+    return await axiosAuth.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,
@@ -45,7 +44,7 @@ const authorize = async (token) => {
 
 const authorizeMaintainer = async (token) => {
   try {
-    return await axiosInstance.get('/authorizeMaintainer', {
+    return await axiosAuth.get('/authorizeMaintainer', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/User/src/helpers/callsToAuth.js
+++ b/User/src/helpers/callsToAuth.js
@@ -2,10 +2,13 @@ const axios = require('axios');
 const env = require('../loadEnvironment.js');
 
 const authRootUrl = env.AUTH_URL + '/auth';
+const axiosInstance = axios.create({
+  baseURL: authRootUrl,
+});
 
 const getToken = async (userInfo) => {
   try {
-    return await axios.post(authRootUrl + '/generate', userInfo, {
+    return await axiosInstance.post('/generate', userInfo, {
       headers: {
         'Content-Type': 'application/json',
       },
@@ -23,7 +26,7 @@ const getToken = async (userInfo) => {
 
 const authorize = async (token) => {
   try {
-    return await axios.get(authRootUrl + '/authorize', {
+    return await axiosInstance.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,
@@ -42,7 +45,7 @@ const authorize = async (token) => {
 
 const authorizeMaintainer = async (token) => {
   try {
-    return await axios.get(authRootUrl + '/authorizeMaintainer', {
+    return await axiosInstance.get('/authorizeMaintainer', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/compose.yml
+++ b/compose.yml
@@ -77,12 +77,6 @@ services:
     container_name: web-ui
     build: ./frontend
     env_file: .env
-    environment:
-      - AUTH_HOST=svc-auth
-      - USER_HOST=svc-user
-      - QUESTION_HOST=svc-question
-      - MATCH_HOST=svc-match
-      - COLLAB_HOST=svc-collab
     depends_on:
       - svc-user
       - svc-auth

--- a/compose.yml
+++ b/compose.yml
@@ -2,46 +2,46 @@ services:
   nginx:
     container_name: nginx
     image: nginx:latest
-    ports: ['80:80']
-    expose: [80]
+    ports: ['3000:80']
     volumes:
       - ./Nginx/nginx.conf:/etc/nginx/nginx.conf
     depends_on:
       - svc-web-ui
+
   db-user:
     container_name: user-storage
     image: mysql/mysql-server:8.0
     env_file: .env
     ports: ['3306:3306']
-    expose: [3306]
     volumes:
       - ./User/initdb:/docker-entrypoint-initdb.d
+
   rabbitmq:
     container_name: rabbitmq
     image: rabbitmq:latest
     ports: ['5672:5672']
-    expose: [5672]
+
   svc-user:
     container_name: user-service
     build: ./User
     env_file: .env
     environment:
-      - MYSQL_HOST=user-storage
-      - AUTH_HOST=auth-service
+      - MYSQL_HOST=db-user
+      - AUTH_HOST=svc-auth
     ports: ['4001:4001']
-    expose: [4001]
     depends_on:
       db-user:
         condition: service_started
         restart: true
       svc-auth:
         condition: service_started
+
   svc-auth:
     container_name: auth-service
     build: ./Auth
     env_file: .env
     ports: ['5001:5001']
-    expose: [5001]
+
   svc-question:
     container_name: question-service
     build: ./Question
@@ -49,40 +49,40 @@ services:
     environment:
       - AUTH_HOST=svc-auth
     ports: ['6001:6001']
-    expose: [6001]
     depends_on:
       - svc-auth
+
   svc-match:
     container_name: match-service
     build: ./Match
     env_file: .env
     environment:
-      - AUTH_HOST=svc-auth
       - RABBITMQ_HOST=rabbitmq
+      - AUTH_HOST=svc-auth
     ports: ['7001:7001']
-    expose: [7001]
     depends_on:
       rabbitmq:
         condition: service_started
         restart: true
       svc-auth:
         condition: service_started
+
   svc-collab:
     container_name: collab-service
     build: ./Collaboration
     env_file: .env
     ports: ['8001:8001']
-    expose: [8001]
+
   svc-web-ui:
     container_name: web-ui
     build: ./frontend
     env_file: .env
     environment:
-      - USER_HOST=user-service
-      - AUTH_HOST=auth-service
-      - QUESTION_HOST=question-service
-      - MATCH_HOST=match-service
-      - COLLAB_HOST=collab-service
+      - AUTH_HOST=svc-auth
+      - USER_HOST=svc-user
+      - QUESTION_HOST=svc-question
+      - MATCH_HOST=svc-match
+      - COLLAB_HOST=svc-collab
     depends_on:
       - svc-user
       - svc-auth

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,13 @@
 services:
+  nginx:
+    container_name: nginx
+    image: nginx:latest
+    ports: ['80:80']
+    expose: [80]
+    volumes:
+      - ./Nginx/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - svc-web-ui
   db-user:
     container_name: user-storage
     image: mysql/mysql-server:8.0
@@ -74,8 +83,6 @@ services:
       - QUESTION_HOST=question-service
       - MATCH_HOST=match-service
       - COLLAB_HOST=collab-service
-    ports: ['3000:3000']
-    expose: [3000]
     depends_on:
       - svc-user
       - svc-auth

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,6 @@ services:
       - ./Nginx/nginx.conf:/etc/nginx/nginx.conf
     depends_on:
       - svc-web-ui
-
   db-user:
     container_name: user-storage
     image: mysql/mysql-server:8.0
@@ -15,12 +14,10 @@ services:
     ports: ['3306:3306']
     volumes:
       - ./User/initdb:/docker-entrypoint-initdb.d
-
   rabbitmq:
     container_name: rabbitmq
     image: rabbitmq:latest
     ports: ['5672:5672']
-
   svc-user:
     container_name: user-service
     build: ./User
@@ -35,13 +32,11 @@ services:
         restart: true
       svc-auth:
         condition: service_started
-
   svc-auth:
     container_name: auth-service
     build: ./Auth
     env_file: .env
     ports: ['5001:5001']
-
   svc-question:
     container_name: question-service
     build: ./Question
@@ -51,7 +46,6 @@ services:
     ports: ['6001:6001']
     depends_on:
       - svc-auth
-
   svc-match:
     container_name: match-service
     build: ./Match
@@ -66,13 +60,11 @@ services:
         restart: true
       svc-auth:
         condition: service_started
-
   svc-collab:
     container_name: collab-service
     build: ./Collaboration
     env_file: .env
     ports: ['8001:8001']
-
   svc-web-ui:
     container_name: web-ui
     build: ./frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,8 +18,5 @@ RUN npm install
 # Bundle the app's source code inside the Docker image.
 COPY . .
 
-# Expose ports so they can be mapped by Docker daemon.
-# EXPOSE 3000
-
 # Define the command to run your app using CMD which defines your runtime.
 CMD ["npm", "run", "start-no-env"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,7 @@ RUN npm install
 COPY . .
 
 # Expose ports so they can be mapped by Docker daemon.
-EXPOSE 3000
+# EXPOSE 3000
 
 # Define the command to run your app using CMD which defines your runtime.
 CMD ["npm", "run", "start-no-env"]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -45,10 +45,7 @@ function App() {
         {/* Question management for normal users */}
         <Route path='/landing' element={<ProtectedRoute />}>
           <Route index element={<Landing />} />
-          <Route
-            path='/landing/question/:id'
-            element={<QuestionDescription />}
-          />
+          <Route path='/landing/question/:id' element={<QuestionDescription />} />
         </Route>
 
         {/* Question management for maintainers only */}
@@ -63,19 +60,13 @@ function App() {
         <Route path='/user-profile' element={<ProtectedRoute />}>
           <Route index element={<ManageUserProfile />} />
           <Route path='/user-profile/edit' element={<NormalEditUser />} />
-          <Route
-            path='/user-profile/change-password'
-            element={<ChangeUserPassword />}
-          />
+          <Route path='/user-profile/change-password' element={<ChangeUserPassword />} />
         </Route>
 
         {/* Profile management for maintainers only */}
         <Route path='/users-management' element={<MaintainerRoute />}>
           <Route index element={<ManageUserProfiles />} />
-          <Route
-            path='/users-management/edit'
-            element={<MaintainerEditUser />}
-          />
+          <Route path='/users-management/edit' element={<MaintainerEditUser />} />
           <Route path='/users-management/new' element={<AddUser />} />
         </Route>
 
@@ -90,12 +81,12 @@ function App() {
         {/* Display UnauthorizedPage component if user is not authorized */}
         <Route path='/unauthorized' element={<UnauthorizedPage />} />
 
-        {/* Display UnauthorizedPage component if user is not authorized */}
+        {/* Display PageNotFound component if route does not exist */}
         <Route path='*' element={<PageNotFound />} />
       </Routes>
       <ToastContainer />
     </div>
   );
-}
+};
 
 export default App;

--- a/frontend/src/api/AuthApi.js
+++ b/frontend/src/api/AuthApi.js
@@ -1,15 +1,9 @@
-import axios from 'axios';
-const env = require('../loadEnvironment.js');
-
-const authRootUrl = env.AUTH_URL + '/auth';
-const axiosInstance = axios.create({
-  baseURL: authRootUrl,
-});
+import { axiosAuth } from '../utils/axios';
 
 // To get userId/isMaintainer
 export const authorize = async (token) => {
   try {
-    return await axiosInstance.get('/authorize', {
+    return await axiosAuth.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/frontend/src/api/AuthApi.js
+++ b/frontend/src/api/AuthApi.js
@@ -2,11 +2,14 @@ import axios from 'axios';
 const env = require('../loadEnvironment.js');
 
 const authRootUrl = env.AUTH_URL + '/auth';
+const axiosInstance = axios.create({
+  baseURL: authRootUrl,
+});
 
 // To get userId/isMaintainer
 export const authorize = async (token) => {
   try {
-    return await axios.get(authRootUrl + '/authorize', {
+    return await axiosInstance.get('/authorize', {
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token,

--- a/frontend/src/api/MatchApi.js
+++ b/frontend/src/api/MatchApi.js
@@ -1,10 +1,4 @@
-import axios from 'axios';
-const env = require('../loadEnvironment');
-
-const rootUrl = env.MATCH_URL + '/queue';
-const axiosInstance = axios.create({
-  baseURL: rootUrl,
-});
+import { axiosMatch } from '../utils/axios';
 
 const getConfig = (jwtToken) => {
   return {
@@ -22,7 +16,7 @@ export const joinQueue = async (jwt, queueName, sessionID) => {
       queueName: queueName,
       sessionID: sessionID,
     };
-    return await axiosInstance.post("/join", data, getConfig(jwt));
+    return await axiosMatch.post('/join', data, getConfig(jwt));
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -41,7 +35,7 @@ export const exitQueue = async (jwt, queueName, sessionID) => {
       queueName: queueName,
       sessionID: sessionID,
     };
-    return await axiosInstance.post("/exit", data, getConfig(jwt));
+    return await axiosMatch.post('/exit', data, getConfig(jwt));
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {

--- a/frontend/src/api/MatchApi.js
+++ b/frontend/src/api/MatchApi.js
@@ -2,6 +2,9 @@ import axios from 'axios';
 const env = require('../loadEnvironment');
 
 const rootUrl = env.MATCH_URL + '/queue';
+const axiosInstance = axios.create({
+  baseURL: rootUrl,
+});
 
 const getConfig = (jwtToken) => {
   return {
@@ -19,7 +22,7 @@ export const joinQueue = async (jwt, queueName, sessionID) => {
       queueName: queueName,
       sessionID: sessionID,
     };
-    return await axios.post(rootUrl + '/join', data, getConfig(jwt));
+    return await axiosInstance.post("/join", data, getConfig(jwt));
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -38,7 +41,7 @@ export const exitQueue = async (jwt, queueName, sessionID) => {
       queueName: queueName,
       sessionID: sessionID,
     };
-    return await axios.post(rootUrl + '/exit', data, getConfig(jwt));
+    return await axiosInstance.post("/exit", data, getConfig(jwt));
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {

--- a/frontend/src/api/QuestionApi.js
+++ b/frontend/src/api/QuestionApi.js
@@ -2,6 +2,9 @@ import axios from 'axios';
 const env = require('../loadEnvironment');
 
 const questionRootUrl = env.QUESTION_URL + '/question';
+const axiosInstance = axios.create({
+  baseURL: questionRootUrl,
+});
 
 const getConfig = (jwtToken) => {
   return {
@@ -26,8 +29,8 @@ export const createQuestion = async (
       description: description,
       tags: tags,
     };
-    return await axios.post(
-      questionRootUrl + '/create',
+    return await axiosInstance.post(
+      '/create',
       questionData,
       getConfig(jwtToken)
     );
@@ -44,10 +47,7 @@ export const createQuestion = async (
 
 export const getQuestions = async (jwtToken) => {
   try {
-    const response = await axios.get(
-      questionRootUrl + '/getAll',
-      getConfig(jwtToken)
-    );
+    const response = await axiosInstance.get('/getAll', getConfig(jwtToken));
     return response.data.questions;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -64,10 +64,7 @@ export const getQuestionsByComplexity = async (complexity, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { complexity: complexity };
-    const response = await axios.get(
-      questionRootUrl + '/getAllByComplexity',
-      config
-    );
+    const response = await axiosInstance.get('/getAllByComplexity', config);
     return response.data.questions;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -84,8 +81,8 @@ export const getQuestionDetails = async (questionId, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { id: questionId };
-    const questionDetails = await axios.get(
-      questionRootUrl + '/getQuestionDetails',
+    const questionDetails = await axiosInstance.get(
+      '/getQuestionDetails',
       config
     );
     return questionDetails.data.question;
@@ -104,8 +101,8 @@ export const getRandomQuestionByCriteria = async (complexity, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { complexity: complexity };
-    const questionDetails = await axios.get(
-      questionRootUrl + '/getRandomQuestionByCriteria',
+    const questionDetails = await axiosInstance.get(
+      '/getRandomQuestionByCriteria',
       config
     );
     return questionDetails.data.question;
@@ -136,11 +133,7 @@ export const editQuestion = async (
       description: description,
       tags: tags,
     };
-    return await axios.post(
-      questionRootUrl + '/edit',
-      questionData,
-      getConfig(jwtToken)
-    );
+    return await axiosInstance.post('/edit', questionData, getConfig(jwtToken));
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -156,7 +149,7 @@ export const deleteQuestion = async (id, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { id: id };
-    const response = await axios.delete(questionRootUrl + '/delete', config);
+    const response = await axiosInstance.delete('/delete', config);
     return response;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {

--- a/frontend/src/api/QuestionApi.js
+++ b/frontend/src/api/QuestionApi.js
@@ -1,10 +1,4 @@
-import axios from 'axios';
-const env = require('../loadEnvironment');
-
-const questionRootUrl = env.QUESTION_URL + '/question';
-const axiosInstance = axios.create({
-  baseURL: questionRootUrl,
-});
+import { axiosQuestion } from '../utils/axios';
 
 const getConfig = (jwtToken) => {
   return {
@@ -29,7 +23,7 @@ export const createQuestion = async (
       description: description,
       tags: tags,
     };
-    return await axiosInstance.post(
+    return await axiosQuestion.post(
       '/create',
       questionData,
       getConfig(jwtToken)
@@ -47,7 +41,7 @@ export const createQuestion = async (
 
 export const getQuestions = async (jwtToken) => {
   try {
-    const response = await axiosInstance.get('/getAll', getConfig(jwtToken));
+    const response = await axiosQuestion.get('/getAll', getConfig(jwtToken));
     return response.data.questions;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -64,7 +58,7 @@ export const getQuestionsByComplexity = async (complexity, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { complexity: complexity };
-    const response = await axiosInstance.get('/getAllByComplexity', config);
+    const response = await axiosQuestion.get('/getAllByComplexity', config);
     return response.data.questions;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -81,7 +75,7 @@ export const getQuestionDetails = async (questionId, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { id: questionId };
-    const questionDetails = await axiosInstance.get(
+    const questionDetails = await axiosQuestion.get(
       '/getQuestionDetails',
       config
     );
@@ -101,7 +95,7 @@ export const getRandomQuestionByCriteria = async (complexity, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { complexity: complexity };
-    const questionDetails = await axiosInstance.get(
+    const questionDetails = await axiosQuestion.get(
       '/getRandomQuestionByCriteria',
       config
     );
@@ -133,7 +127,7 @@ export const editQuestion = async (
       description: description,
       tags: tags,
     };
-    return await axiosInstance.post('/edit', questionData, getConfig(jwtToken));
+    return await axiosQuestion.post('/edit', questionData, getConfig(jwtToken));
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -149,7 +143,7 @@ export const deleteQuestion = async (id, jwtToken) => {
   try {
     let config = getConfig(jwtToken);
     config.params = { id: id };
-    const response = await axiosInstance.delete('/delete', config);
+    const response = await axiosQuestion.delete('/delete', config);
     return response;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {

--- a/frontend/src/api/UserApi.js
+++ b/frontend/src/api/UserApi.js
@@ -2,6 +2,9 @@ import axios from 'axios';
 const env = require('../loadEnvironment');
 
 const userRootUrl = env.USER_URL + '/user';
+const axiosInstance = axios.create({
+  baseURL: userRootUrl,
+});
 
 const getConfig = () => {
   return {
@@ -22,7 +25,7 @@ const getTokenConfig = (jwtToken) => {
 
 export const signup = async (userData) => {
   try {
-    return await axios.post(userRootUrl + '/signup', userData, getConfig());
+    return await axiosInstance.post('/signup', userData, getConfig());
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -36,7 +39,7 @@ export const signup = async (userData) => {
 
 export const login = async (userData) => {
   try {
-    return await axios.post(userRootUrl + '/login', userData, getConfig());
+    return await axiosInstance.post('/login', userData, getConfig());
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -50,10 +53,7 @@ export const login = async (userData) => {
 
 export const getAllUsers = async (jwtToken) => {
   try {
-    const res = await axios.get(
-      userRootUrl + '/readAll',
-      getTokenConfig(jwtToken)
-    );
+    const res = await axiosInstance.get('/readAll', getTokenConfig(jwtToken));
     return res.data.info;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -68,8 +68,8 @@ export const getAllUsers = async (jwtToken) => {
 
 export const getUser = async (id, jwtToken) => {
   try {
-    const res = await axios.post(
-      userRootUrl + '/read',
+    const res = await axiosInstance.post(
+      '/read',
       { id },
       getTokenConfig(jwtToken)
     );
@@ -87,8 +87,8 @@ export const getUser = async (id, jwtToken) => {
 
 export const updateUsername = async (id, newUsername, jwtToken) => {
   try {
-    const res = await axios.post(
-      userRootUrl + '/update',
+    const res = await axiosInstance.post(
+      '/update',
       { id: id, username: newUsername },
       getTokenConfig(jwtToken)
     );
@@ -112,8 +112,8 @@ export const updatePassword = async (
   jwtToken
 ) => {
   try {
-    return await axios.post(
-      userRootUrl + '/change-password',
+    return await axiosInstance.post(
+      '/change-password',
       {
         id: id,
         currentPassword: currentPassword,
@@ -135,8 +135,8 @@ export const updatePassword = async (
 
 export const deleteUser = async (id, jwtToken) => {
   try {
-    return await axios.post(
-      userRootUrl + '/delete',
+    return await axiosInstance.post(
+      '/delete',
       { id },
       getTokenConfig(jwtToken)
     );

--- a/frontend/src/api/UserApi.js
+++ b/frontend/src/api/UserApi.js
@@ -1,10 +1,4 @@
-import axios from 'axios';
-const env = require('../loadEnvironment');
-
-const userRootUrl = env.USER_URL + '/user';
-const axiosInstance = axios.create({
-  baseURL: userRootUrl,
-});
+import { axiosUser } from '../utils/axios';
 
 const getConfig = () => {
   return {
@@ -25,7 +19,7 @@ const getTokenConfig = (jwtToken) => {
 
 export const signup = async (userData) => {
   try {
-    return await axiosInstance.post('/signup', userData, getConfig());
+    return await axiosUser.post('/signup', userData, getConfig());
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -39,7 +33,7 @@ export const signup = async (userData) => {
 
 export const login = async (userData) => {
   try {
-    return await axiosInstance.post('/login', userData, getConfig());
+    return await axiosUser.post('/login', userData, getConfig());
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {
@@ -53,7 +47,7 @@ export const login = async (userData) => {
 
 export const getAllUsers = async (jwtToken) => {
   try {
-    const res = await axiosInstance.get('/readAll', getTokenConfig(jwtToken));
+    const res = await axiosUser.get('/readAll', getTokenConfig(jwtToken));
     return res.data.info;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -68,11 +62,7 @@ export const getAllUsers = async (jwtToken) => {
 
 export const getUser = async (id, jwtToken) => {
   try {
-    const res = await axiosInstance.post(
-      '/read',
-      { id },
-      getTokenConfig(jwtToken)
-    );
+    const res = await axiosUser.post('/read', { id }, getTokenConfig(jwtToken));
     return res.data.info;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -87,7 +77,7 @@ export const getUser = async (id, jwtToken) => {
 
 export const updateUsername = async (id, newUsername, jwtToken) => {
   try {
-    const res = await axiosInstance.post(
+    const res = await axiosUser.post(
       '/update',
       { id: id, username: newUsername },
       getTokenConfig(jwtToken)
@@ -112,7 +102,7 @@ export const updatePassword = async (
   jwtToken
 ) => {
   try {
-    return await axiosInstance.post(
+    return await axiosUser.post(
       '/change-password',
       {
         id: id,
@@ -135,11 +125,7 @@ export const updatePassword = async (
 
 export const deleteUser = async (id, jwtToken) => {
   try {
-    return await axiosInstance.post(
-      '/delete',
-      { id },
-      getTokenConfig(jwtToken)
-    );
+    return await axiosUser.post('/delete', { id }, getTokenConfig(jwtToken));
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
       throw Object.assign(new Error(err.code), {

--- a/frontend/src/loadEnvironment.js
+++ b/frontend/src/loadEnvironment.js
@@ -1,40 +1,27 @@
 // Config for this service
 const SERVER_HOST = process.env.REACT_APP_HOST || 'http://localhost';
-const SERVER_PORT = process.env.REACT_APP_SERVER_PORT || 3001;
-const SERVER_URL = SERVER_HOST + ':' + SERVER_PORT;
 
 // Dependency Config: User Service
-// const USER_HOST = process.env.USER_HOST || 'localhost';
-// const USER_PORT = process.env.REACT_APP_USER_PORT || 4001;
-// const USER_URL = 'http://' + USER_HOST + ':' + USER_PORT;
-const USER_URL = 'http://localhost:4001';
+const USER_PORT = process.env.REACT_APP_USER_PORT || 4001;
+const USER_URL = SERVER_HOST + ':' + USER_PORT;
 
 // Dependency Config: Auth Service
-// const AUTH_HOST = process.env.AUTH_HOST || 'localhost';
-// const AUTH_PORT = process.env.REACT_APP_AUTH_PORT || 5001;
-// const AUTH_URL = 'http://' + AUTH_HOST + ':' + AUTH_PORT;
-const AUTH_URL = 'http://localhost:5001';
+const AUTH_PORT = process.env.REACT_APP_AUTH_PORT || 5001;
+const AUTH_URL = SERVER_HOST + ':' + AUTH_PORT;
 
 // Dependency Config: Question Service
-// const QUESTION_HOST = process.env.QUESTION_HOST || 'localhost';
-// const QUESTION_PORT = process.env.REACT_APP_QUESTION_PORT || 6001;
-// const QUESTION_URL = 'http://' + QUESTION_HOST + ':' + QUESTION_PORT;
-const QUESTION_URL = 'http://localhost:6001';
+const QUESTION_PORT = process.env.REACT_APP_QUESTION_PORT || 6001;
+const QUESTION_URL = SERVER_HOST + ':' + QUESTION_PORT;
 
 // Dependency Config: Match Service
-// const MATCH_HOST = process.env.MATCH_HOST || 'localhost';
-// const MATCH_PORT = process.env.REACT_APP_MATCH_PORT || 7001;
-// const MATCH_URL = 'http://' + MATCH_HOST + ':' + MATCH_PORT;
-const MATCH_URL = 'http://localhost:7001';
+const MATCH_PORT = process.env.REACT_APP_MATCH_PORT || 7001;
+const MATCH_URL = SERVER_HOST + ':' + MATCH_PORT;
 
 // // Dependency Config: Collaboration Service
-// const COLLAB_HOST = process.env.COLLAB_HOST || 'localhost';
-// const COLLAB_PORT = process.env.REACT_APP_COLLAB_PORT || 8001;
-// const COLLAB_URL = 'http://' + COLLAB_HOST + ':' + COLLAB_PORT;
-const COLLAB_URL = 'http://localhost:8001';
+const COLLAB_PORT = process.env.REACT_APP_COLLAB_PORT || 8001;
+const COLLAB_URL = SERVER_HOST + ':' + COLLAB_PORT;
 
 module.exports = {
-  SERVER_URL,
   USER_URL,
   AUTH_URL,
   QUESTION_URL,

--- a/frontend/src/loadEnvironment.js
+++ b/frontend/src/loadEnvironment.js
@@ -4,29 +4,34 @@ const SERVER_PORT = process.env.REACT_APP_SERVER_PORT || 3001;
 const SERVER_URL = SERVER_HOST + ':' + SERVER_PORT;
 
 // Dependency Config: User Service
-const USER_HOST = process.env.USER_HOST || 'localhost';
-const USER_PORT = process.env.REACT_APP_USER_PORT || 4001;
-const USER_URL = 'http://' + USER_HOST + ':' + USER_PORT;
+// const USER_HOST = process.env.USER_HOST || 'localhost';
+// const USER_PORT = process.env.REACT_APP_USER_PORT || 4001;
+// const USER_URL = 'http://' + USER_HOST + ':' + USER_PORT;
+const USER_URL = 'http://localhost:4001';
 
 // Dependency Config: Auth Service
-const AUTH_HOST = process.env.AUTH_HOST || 'localhost';
-const AUTH_PORT = process.env.REACT_APP_AUTH_PORT || 5001;
-const AUTH_URL = 'http://' + AUTH_HOST + ':' + AUTH_PORT;
+// const AUTH_HOST = process.env.AUTH_HOST || 'localhost';
+// const AUTH_PORT = process.env.REACT_APP_AUTH_PORT || 5001;
+// const AUTH_URL = 'http://' + AUTH_HOST + ':' + AUTH_PORT;
+const AUTH_URL = 'http://localhost:5001';
 
 // Dependency Config: Question Service
-const QUESTION_HOST = process.env.QUESTION_HOST || 'localhost';
-const QUESTION_PORT = process.env.REACT_APP_QUESTION_PORT || 6001;
-const QUESTION_URL = 'http://' + QUESTION_HOST + ':' + QUESTION_PORT;
+// const QUESTION_HOST = process.env.QUESTION_HOST || 'localhost';
+// const QUESTION_PORT = process.env.REACT_APP_QUESTION_PORT || 6001;
+// const QUESTION_URL = 'http://' + QUESTION_HOST + ':' + QUESTION_PORT;
+const QUESTION_URL = 'http://localhost:6001';
 
 // Dependency Config: Match Service
-const MATCH_HOST = process.env.MATCH_HOST || 'localhost';
-const MATCH_PORT = process.env.REACT_APP_MATCH_PORT || 7001;
-const MATCH_URL = 'http://' + MATCH_HOST + ':' + MATCH_PORT;
+// const MATCH_HOST = process.env.MATCH_HOST || 'localhost';
+// const MATCH_PORT = process.env.REACT_APP_MATCH_PORT || 7001;
+// const MATCH_URL = 'http://' + MATCH_HOST + ':' + MATCH_PORT;
+const MATCH_URL = 'http://localhost:7001';
 
-// Dependency Config: Collaboration Service
-const COLLAB_HOST = process.env.COLLAB_HOST || 'localhost';
-const COLLAB_PORT = process.env.REACT_APP_COLLAB_PORT || 8001;
-const COLLAB_URL = 'http://' + COLLAB_HOST + ':' + COLLAB_PORT;
+// // Dependency Config: Collaboration Service
+// const COLLAB_HOST = process.env.COLLAB_HOST || 'localhost';
+// const COLLAB_PORT = process.env.REACT_APP_COLLAB_PORT || 8001;
+// const COLLAB_URL = 'http://' + COLLAB_HOST + ':' + COLLAB_PORT;
+const COLLAB_URL = 'http://localhost:8001';
 
 module.exports = {
   SERVER_URL,

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1,17 +1,18 @@
 import axios from 'axios';
+const env = require('../loadEnvironment.js');
 
 export const axiosUser = axios.create({
-  baseURL: '/user',
+  baseURL: env.USER_URL + '/user',
 });
 
 export const axiosAuth = axios.create({
-  baseURL: '/auth',
+  baseURL: env.AUTH_URL + '/auth',
 });
 
 export const axiosQuestion = axios.create({
-  baseURL: '/question',
+  baseURL: env.QUESTION_URL + '/question',
 });
 
 export const axiosMatch = axios.create({
-  baseURL: '/queue',
+  baseURL: env.MATCH_URL + '/queue',
 });

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+export const axiosUser = axios.create({
+  baseURL: '/user',
+});
+
+export const axiosAuth = axios.create({
+  baseURL: '/auth',
+});
+
+export const axiosQuestion = axios.create({
+  baseURL: '/question',
+});
+
+export const axiosMatch = axios.create({
+  baseURL: '/queue',
+});


### PR DESCRIPTION
This PR consists of:

- adding Nginx as an API Gateway through reverse proxy
- Through Nginx, frontend API Calls is are able to directly use relative path such as 'auth/generate' without specifying 'http://localhost:5001/auth/generate' or 'http://svc-auth:5001/auth/generate' (Docker) as Nginx will provide such routing.
- However, currently .env implementation still maintains mapping for localhosts (e.g., http://localhost:5001) to accommodate when running locally
- Microservices via Docker still requires the use of  service names (e.g., http://svc-auth:5001) when routing (currently unable to route back to use Nginx reverse proxy). May look to fix this in a subsequent update, to standardize the use of localhost only.
- Also created a Axios utility folder for cleaner code and easier maintainence under frontend folder
- Tested and able to run via both docker and local.