### PR TITLE
Update execution to use spawn instead of exec

### DIFF
--- a/Execution/package-lock.json
+++ b/Execution/package-lock.json
@@ -11,13 +11,9 @@
       "dependencies": {
         "axios": "^1.5.1",
         "body-parser": "^1.20.2",
-        "compile-run": "^2.3.4",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
-        "express": "^4.18.2",
-        "JSCPP": "^2.0.9",
-        "jspython-interpreter": "^2.1.15",
-        "python-shell": "^5.0.0"
+        "express": "^4.18.2"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -205,11 +201,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/compile-run": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/compile-run/-/compile-run-2.3.4.tgz",
-      "integrity": "sha512-O0veikr1Lkbq6uBpow7qDi2v/37GJKYghwJzpp5zfU4uVcgVcU0jz6mzCQeux1HCqknHNijEnJ7+yRJ0b/UcQA=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -725,26 +716,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/JSCPP": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/JSCPP/-/JSCPP-2.0.9.tgz",
-      "integrity": "sha512-ix62BbyR33JfuLS5JN3lrP5WrDFHJMe498TbyEN0vjRgK1pvOREs03YA0rMoj0U2h9EYLSoo9emZMW2rSlFVfQ==",
-      "dependencies": {
-        "lodash": "^4.17.20",
-        "pegjs-util": "^1.4.21",
-        "printf": "^0.6.0"
-      }
-    },
-    "node_modules/jspython-interpreter": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/jspython-interpreter/-/jspython-interpreter-2.1.15.tgz",
-      "integrity": "sha512-Xx8Cah1c+3rb4Xn12QdM63agZra3ncBo+FnuCT2p0alUl9bo19/AohJXe6HSXc2LzYqRvcKUvKM6Lo3pr0SFfw=="
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -925,25 +896,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "node_modules/pegjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==",
-      "bin": {
-        "pegjs": "bin/pegjs"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/pegjs-util": {
-      "version": "1.4.21",
-      "resolved": "https://registry.npmjs.org/pegjs-util/-/pegjs-util-1.4.21.tgz",
-      "integrity": "sha512-0z15BXCjxwgeD+pO5QImUgOFsJ86jFt6oDqatveLggeARSS5wmrt9SxCONkUvOeSsob2faVBC9H4wpl4zudg9A==",
-      "dependencies": {
-        "pegjs": ">=0.10.0"
-      }
-    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -954,14 +906,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/printf": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/printf/-/printf-0.6.1.tgz",
-      "integrity": "sha512-is0ctgGdPJ5951KulgfzvHGwJtZ5ck8l042vRkV6jrkpBzTmb/lueTqguWHy2JfVA+RY6gFVlaZgUS0j7S/dsw==",
-      "engines": {
-        "node": ">= 0.9.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -986,14 +930,6 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
-    },
-    "node_modules/python-shell": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
-      "integrity": "sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/qs": {
       "version": "6.11.0",

--- a/Execution/package-lock.json
+++ b/Execution/package-lock.json
@@ -11,18 +11,23 @@
       "dependencies": {
         "axios": "^1.5.1",
         "body-parser": "^1.20.2",
+        "compile-run": "^2.3.4",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "JSCPP": "^2.0.9",
-        "nodemon": "^3.0.1",
+        "jspython-interpreter": "^2.1.15",
         "python-shell": "^5.0.0"
+      },
+      "devDependencies": {
+        "nodemon": "^3.0.1"
       }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -40,6 +45,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -71,12 +77,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -121,6 +129,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -130,6 +139,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -162,6 +172,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -195,10 +206,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compile-run": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/compile-run/-/compile-run-2.3.4.tgz",
+      "integrity": "sha512-O0veikr1Lkbq6uBpow7qDi2v/37GJKYghwJzpp5zfU4uVcgVcU0jz6mzCQeux1HCqknHNijEnJ7+yRJ0b/UcQA=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -248,6 +265,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -422,6 +440,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -511,6 +530,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -546,6 +566,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -568,6 +589,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -645,7 +667,8 @@
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -664,6 +687,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -675,6 +699,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -683,6 +708,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -694,6 +720,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -708,6 +735,11 @@
         "printf": "^0.6.0"
       }
     },
+    "node_modules/jspython-interpreter": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/jspython-interpreter/-/jspython-interpreter-2.1.15.tgz",
+      "integrity": "sha512-Xx8Cah1c+3rb4Xn12QdM63agZra3ncBo+FnuCT2p0alUl9bo19/AohJXe6HSXc2LzYqRvcKUvKM6Lo3pr0SFfw=="
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -717,6 +749,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -779,6 +812,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -803,6 +837,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
       "integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
+      "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^3.2.7",
@@ -830,6 +865,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -844,6 +880,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -911,6 +948,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -946,7 +984,8 @@
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
     },
     "node_modules/python-shell": {
       "version": "5.0.0",
@@ -996,6 +1035,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -1031,6 +1071,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1127,6 +1168,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
       "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -1146,6 +1188,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1157,6 +1200,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1176,6 +1220,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
       "dependencies": {
         "nopt": "~1.0.10"
       },
@@ -1198,7 +1243,8 @@
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1227,7 +1273,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   }
 }

--- a/Execution/package.json
+++ b/Execution/package.json
@@ -12,11 +12,15 @@
   "dependencies": {
     "axios": "^1.5.1",
     "body-parser": "^1.20.2",
+    "compile-run": "^2.3.4",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "JSCPP": "^2.0.9",
-    "nodemon": "^3.0.1",
+    "jspython-interpreter": "^2.1.15",
     "python-shell": "^5.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
   }
 }

--- a/Execution/package.json
+++ b/Execution/package.json
@@ -12,13 +12,9 @@
   "dependencies": {
     "axios": "^1.5.1",
     "body-parser": "^1.20.2",
-    "compile-run": "^2.3.4",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
-    "express": "^4.18.2",
-    "JSCPP": "^2.0.9",
-    "jspython-interpreter": "^2.1.15",
-    "python-shell": "^5.0.0"
+    "express": "^4.18.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/Execution/src/ExecutionController.js
+++ b/Execution/src/ExecutionController.js
@@ -1,52 +1,77 @@
-const { exec } = require('child_process');
+const fs = require('fs');
+const { exec, spawn } = require('child_process');
+const { MAX_EXECUTION_TIME, TIMEOUT_ERROR } = require('./constants');
+const logger = require('./Log');
 
-// execute python
-const executePython = async (req, res) => {
-  // Set a maximum execution time (in milliseconds)
-  const maxExecutionTime = 5000; // 5 seconds
-
+// Execute python code
+const executePython = (req, res) => {
   try {
     const pythonCode = req.body.code;
+    const scriptPath = 'temp_script.py';
+    fs.writeFileSync(scriptPath, pythonCode); // Write the code to a temporary python file
 
-    const scriptProcess = exec(`python -c "${pythonCode.replace(/"/g, '\\"')}"`, (error, stdout, stderr) => {
-      clearTimeout(timeout); // Clear the timeout since the script completed
-      if (error) {
-        res.json({ output: stderr });
-      } else {
-        res.json({ output: stdout });
+    const pythonProcess = spawn('python', [scriptPath]); // Command to execute the script
+    let hasResponded = false;
+
+    const scriptTimeout = setTimeout(() => {
+      logger.error('Python script execution timed out. Killing the script...');
+      pythonProcess.kill('SIGINT'); // Send an interrupt signal to the Python process
+      if (!hasResponded) {
+        hasResponded = true;
+        res.json({
+          output: `${TIMEOUT_ERROR}: Your program has timed out. Please try again.`,
+        });
       }
+    }, MAX_EXECUTION_TIME);
+
+    const output = [];
+    let errorOutput = '';
+
+    pythonProcess.stdout.on('data', (data) => {
+      output.push(data.toString());
     });
 
-    // Set a timeout to kill the script if it runs for too long
-    const timeout = setTimeout(() => {
-      console.error('Python script execution timed out. Killing the script...');
-      scriptProcess.kill();
-      // res.json({ output: "TimeoutError" });
-    }, maxExecutionTime);
+    pythonProcess.stderr.on('data', (data) => {
+      errorOutput = 'Error: ';
+    });
 
+    pythonProcess.on('exit', (code) => {
+      clearTimeout(scriptTimeout);
+
+      if (!hasResponded) {
+        hasResponded = true;
+        if (code === 0) {
+          res.json({ output: output.join('') });
+        } else {
+          res.json({ output: errorOutput });
+        }
+      }
+
+      fs.unlinkSync(scriptPath);
+    });
   } catch (err) {
     console.log(err);
-  };
+  }
 };
 
 // execute java
 const executeJava = async (req, res) => {
   try {
-    console.log(req.body)
-    res.json({ message: "java code executed"})
+    console.log(req.body);
+    res.json({ message: 'java code executed' });
   } catch (err) {
     throw err;
-  };
+  }
 };
 
 // execute cpp
 const executeCpp = async (req, res) => {
   try {
-    console.log(req.body)
-    res.json({ message: "cpp code executed"})
+    console.log(req.body);
+    res.json({ message: 'cpp code executed' });
   } catch (err) {
     throw err;
-  };
+  }
 };
 
 const executeJs = async (req, res) => {
@@ -54,24 +79,28 @@ const executeJs = async (req, res) => {
     const maxExecutionTime = 5000; // 5 seconds
     const javascriptCode = req.body.code;
 
-    const scriptProcess = exec(`node -e "${javascriptCode.replace(/"/g, '\\"')}"`, (error, stdout, stderr) => {
-      clearTimeout(timeout); // Clear the timeout since the script completed
-      if (error) {
-        res.json({ output: stderr });
-      } else {
-        res.json({ output: stdout });
+    const scriptProcess = exec(
+      `node -e "${javascriptCode.replace(/"/g, '\\"')}"`,
+      (error, stdout, stderr) => {
+        clearTimeout(timeout); // Clear the timeout since the script completed
+        if (error) {
+          res.json({ output: stderr });
+        } else {
+          res.json({ output: stdout });
+        }
       }
-    });
+    );
 
     const timeout = setTimeout(() => {
-      console.error('JavaScript script execution timed out. Killing the script...');
+      console.error(
+        'JavaScript script execution timed out. Killing the script...'
+      );
       scriptProcess.kill();
       // res.json({ output: "TimeoutError" });
     }, maxExecutionTime);
-
   } catch (err) {
     console.log(err);
-  };
+  }
 };
 
 module.exports = {

--- a/Execution/src/ExecutionRoutes.js
+++ b/Execution/src/ExecutionRoutes.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 
-const executionController = require('./ExecutionController.js');
+const executionController = require('./ExecutionController');
 
 router.post('/execute-python', executionController.executePython);
 router.post('/execute-java', executionController.executeJava);

--- a/Execution/src/ExecutionServer.js
+++ b/Execution/src/ExecutionServer.js
@@ -3,13 +3,19 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const executionRoutes = require('./ExecutionRoutes');
 const env = require('./loadEnvironment');
+const logger = require('./Log');
 
-console.log('Starting ExecutionServer ...');
+logger.register({
+  serviceName: 'Execution Service',
+  logLevel: logger.LOG_LEVELS.all,
+});
+
+logger.log('Starting ...');
 
 const app = express();
 app.use(cors());
 app.use(bodyParser.json());
 app.use('/execute', executionRoutes);
 app.listen(env.EXECUTION_PORT, () => {
-  console.log(`ExecutionServer is running on port: ${env.EXECUTION_PORT}`);
+  logger.log(`Running on port: ${env.EXECUTION_PORT}`);
 });

--- a/Execution/src/Log.js
+++ b/Execution/src/Log.js
@@ -1,0 +1,56 @@
+const LOG_LEVELS = {
+    all: 0,
+    debug: 1,
+    log: 2,
+    warn: 4,
+    error: 8,
+    quiet: 16
+}
+
+var _name = '';
+var _logLevel = LOG_LEVELS.quiet;
+
+// If logger is not registered, no logs are printed
+const register = (config) => {
+    _name = '[' + (config.serviceName ?? '???') + ']';
+    _logLevel = config.logLevel ?? LOG_LEVELS.all;
+};
+
+const debug = (...msg) => {
+    if (_logLevel <= LOG_LEVELS.debug)
+        console.debug(_name, "DEBUG  :", ...msg);
+};
+
+const log = (...msg) => {
+    if (_logLevel <= LOG_LEVELS.log)
+        console.log(_name, "INFO   :", ...msg);
+};
+
+const logSuccess = (...msg) => {
+    if (_logLevel <= LOG_LEVELS.log)
+        console.log(_name, "SUCCESS:", ...msg);
+};
+
+const logFailure = (...msg) => {
+    if (_logLevel <= LOG_LEVELS.log)
+        console.log(_name, "FAILURE:", ...msg);
+};
+
+const warn = (...msg) => {
+    if (_logLevel <= LOG_LEVELS.warn)
+        console.warn(_name, "WARNING:", ...msg);
+};
+
+const error = (...msg) => {
+    if (_logLevel <= LOG_LEVELS.error)
+        console.error(_name, "ERROR  :", ...msg);
+};
+
+module.exports = {
+    LOG_LEVELS,
+    register,
+    debug, 
+    log, logSuccess, logFailure,
+    warn,
+    error
+};

--- a/Execution/src/constants/index.js
+++ b/Execution/src/constants/index.js
@@ -1,0 +1,8 @@
+const MAX_EXECUTION_TIME = 5000; // 5 seconds
+
+const TIMEOUT_ERROR = 'TimeoutError';
+
+module.exports = {
+  MAX_EXECUTION_TIME,
+  TIMEOUT_ERROR,
+};

--- a/frontend/src/api/ExecutionApi.js
+++ b/frontend/src/api/ExecutionApi.js
@@ -1,4 +1,5 @@
 import { axiosExecution } from '../utils/axios';
+import { Language } from '../constants';
 
 const getConfig = () => {
   return {
@@ -12,27 +13,31 @@ export const executeCode = async (language, code) => {
   const codeObject = { code: code };
 
   switch (language) {
-    case 'Python':
-      console.log("case python")
+    case Language.PYTHON:
+      console.log('case python');
       return await executePython(codeObject);
-    case 'Java':
-      console.log("case java")
+    case Language.JAVA:
+      console.log('case java');
       return await executeJava(codeObject);
-    case 'C++':
-      console.log("case cpp")
+    case Language.CPP:
+      console.log('case cpp');
       return await executeCpp(codeObject);
-    case 'Javascript':
-      console.log("case js")
+    case Language.JS:
+      console.log('case js');
       return await executeJs(codeObject);
     default:
-      console.log("case python")
+      console.log('case python');
       return await executePython(codeObject);
   }
 };
 
 const executePython = async (codeObject) => {
   try {
-    const response = await axiosExecution.post('/execute-python', codeObject, getConfig());
+    const response = await axiosExecution.post(
+      '/execute-python',
+      codeObject,
+      getConfig()
+    );
     return response.data.output;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -43,11 +48,15 @@ const executePython = async (codeObject) => {
     }
     throw err;
   }
-}
+};
 
 const executeJava = async (codeObject) => {
   try {
-    const response = await axiosExecution.post('/execute-java', codeObject, getConfig());
+    const response = await axiosExecution.post(
+      '/execute-java',
+      codeObject,
+      getConfig()
+    );
     return response.data.output;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -62,7 +71,11 @@ const executeJava = async (codeObject) => {
 
 const executeCpp = async (codeObject) => {
   try {
-    const response = await axiosExecution.post('/execute-cpp', codeObject, getConfig());
+    const response = await axiosExecution.post(
+      '/execute-cpp',
+      codeObject,
+      getConfig()
+    );
     return response.data.output;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {
@@ -77,8 +90,12 @@ const executeCpp = async (codeObject) => {
 
 const executeJs = async (codeObject) => {
   try {
-    const response = await axiosExecution.post('/execute-js', codeObject, getConfig());
-    console.log(response.data.output)
+    const response = await axiosExecution.post(
+      '/execute-js',
+      codeObject,
+      getConfig()
+    );
+    console.log(response.data.output);
     return response.data.output;
   } catch (err) {
     if (err.code === 'ERR_NETWORK') {

--- a/frontend/src/components/Collaboration/CodeEditor.js
+++ b/frontend/src/components/Collaboration/CodeEditor.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { EditorView } from '@codemirror/view';
-import { vscodeDark } from "@uiw/codemirror-theme-vscode";
+import { vscodeDark } from '@uiw/codemirror-theme-vscode';
 import { python } from '@codemirror/lang-python';
 import { java } from '@codemirror/lang-java';
 import { cpp } from '@codemirror/lang-cpp';
@@ -60,7 +60,10 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
   const getAbsolutePosition = (relativePosition) => {
     if (editorBoxRef.current) {
       const { top, left } = editorBoxRef.current.getBoundingClientRect();
-      return { x: relativePosition.x + left - scrollLeft, y: relativePosition.y + top - scrollTop };
+      return {
+        x: relativePosition.x + left - scrollLeft,
+        y: relativePosition.y + top - scrollTop,
+      };
     }
   };
 
@@ -68,7 +71,10 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
   const getRelativePosition = (absolutePosition) => {
     if (editorBoxRef.current) {
       const { top, left } = editorBoxRef.current.getBoundingClientRect();
-      return { x: absolutePosition.x - left + scrollLeft, y: absolutePosition.y - top + scrollTop };
+      return {
+        x: absolutePosition.x - left + scrollLeft,
+        y: absolutePosition.y - top + scrollTop,
+      };
     }
   };
 
@@ -118,7 +124,7 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
   const handleCodeExecution = async () => {
     try {
       const result = await executeCode(language, code);
-      console.log(result)
+      console.log(result);
       setResult(result);
 
       // Send execution results to the server
@@ -131,7 +137,14 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
     }
   };
 
-  // Send code changes to the server
+  // Retrieve the stored code from session storage (e.g. when the user refreshes the page)
+  useEffect(() => {
+    const storedContent = sessionStorage.getItem(`codeEditorContent_${roomId}`);
+    if (storedContent) {
+      setCode(storedContent);
+    }
+  }, []);
+
   // Render the partner's cursor
   useEffect(() => {
     if (editorBoxRef.current) {
@@ -142,27 +155,11 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
           x: partner?.position?.x + left - scrollLeft,
           y: partner?.position?.y + top - scrollTop,
         },
-      }
+      };
       setRenderPartner(newPartnerCursor);
     }
   }, [scrollTop, scrollLeft, partner]);
 
-  // Retrieve the stored code from session storage (e.g. when the user refreshes the page)
-  useEffect(() => {
-    const storedContent = sessionStorage.getItem(`codeEditorContent_${roomId}`);
-    if (storedContent) {
-      setCode(storedContent);
-    }
-  }, []);
-
-  // Receive result update from the server
-  useEffect(() => {
-    socket.on(Event.Collaboration.RESULT_UPDATE, (updatedResult) => {
-      setResult(updatedResult);
-    });
-  }, [result]);
-
-  // Receive language changes from the server
   useEffect(() => {
     // Receive code changes from the server
     socket.on(Event.Collaboration.CODE_UPDATE, (updatedCode) => {
@@ -193,7 +190,10 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
         setShowCursor(false);
       }
     });
-
+    // Receive result changes from the server
+    socket.on(Event.Collaboration.RESULT_UPDATE, (updatedResult) => {
+      setResult(updatedResult);
+    });
   }, [socket]);
 
   // Hide the partner's cursor after 5 seconds of inactivity
@@ -209,7 +209,7 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
   return (
     <div className='editor-container'>
       <div className='row editor-nav-bar'>
-        <div className='col-sm-2'>
+        <div className='d-flex flex-wrap gap-1'>
           <select
             className='form-select-sm'
             id='languageSelect'
@@ -221,12 +221,17 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
             <option value='C++'>C++</option>
             <option value='Javascript'>Javascript</option>
           </select>
-          <button type='button' onClick={handleCodeExecution}>
-            Run code
+          <button
+            type='button'
+            className='btn btn-success me-2'
+            onClick={handleCodeExecution}
+          >
+            ▶ Run
           </button>
         </div>
       </div>
-      <div className='code-editor'
+      <div
+        className='code-editor'
         onScroll={handleScroll}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
@@ -241,8 +246,9 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
           placeholder='Enter your code here...'
           extensions={[getLanguageExtension(language)]}
         />
-        {isWithinWindow(renderPartner.position, editorBoxRef) && showCursor &&
-          <OverlayCursor partner={renderPartner} />}
+        {isWithinWindow(renderPartner.position, editorBoxRef) && showCursor && (
+          <OverlayCursor partner={renderPartner} />
+        )}
       </div>
       <div className='output-container'>
         <textarea

--- a/frontend/src/components/Collaboration/CodeEditor.js
+++ b/frontend/src/components/Collaboration/CodeEditor.js
@@ -20,6 +20,7 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
   const [code, setCode] = useState('');
   const [result, setResult] = useState('');
   const [language, setLanguage] = useState(selectedLanguage);
+  const [isExecuting, setIsExecuting] = useState(false);
 
   // Initialize cursor position for code editor
   const [scrollTop, setScrollTop] = useState(0);
@@ -123,6 +124,8 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
 
   const handleCodeExecution = async () => {
     try {
+      setIsExecuting(true);
+
       const result = await executeCode(language, code);
       console.log(result);
       setResult(result);
@@ -134,6 +137,8 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
       });
     } catch (err) {
       errorHandler(err);
+    } finally {
+      setIsExecuting(false);
     }
   };
 
@@ -223,8 +228,9 @@ const CodeEditor = ({ socket, roomId, selectedLanguage, displayName, jwt }) => {
           </select>
           <button
             type='button'
-            className='btn btn-success me-2'
+            className={`btn ${isExecuting ? 'btn-secondary' : 'btn-success'} me-2`}
             onClick={handleCodeExecution}
+            disabled={isExecuting}
           >
             ▶ Run
           </button>

--- a/frontend/src/components/MatchMaking/MatchingModal.js
+++ b/frontend/src/components/MatchMaking/MatchingModal.js
@@ -128,6 +128,7 @@ const MatchingModal = ({ isOpen, onClose }) => {
                         <option value={Language.PYTHON}>{Language.PYTHON}</option>
                         <option value={Language.JAVA}>{Language.JAVA}</option>
                         <option value={Language.CPP}>{Language.CPP}</option>
+                        <option value={Language.JS}>{Language.JS}</option>
                       </select>
                       <label htmlFor='matchingQuestitonLanguage'>
                         Programming Language


### PR DESCRIPTION
This PR consists of:
- updating execution of python and javascript code to use spawn instead of exec
- execution will create temporary local files before destroying when execution ends
- extracted out the common execution code into a function
- added UI for execution button
    - green = can execution
    - grey = disabled, execution is running