### PR TITLE
Safari Authorization bug fix

### DIFF
--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -36,8 +36,7 @@ const Login = () => {
       const response = await login(userData);
 
       Cookies.set('jwt', response.data.token, {
-        secure: true,
-        sameSite: 'strict',
+        sameSite: 'Lax',
       });
 
       navigate('/landing');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "PeerPrep",
+  "name": "ay2324s1-course-assessment-g32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
<b>Issue</b>
Safari has stricter cookie settings. Since the code specified cookie should be saved only on HTTPS connection, safari browser will not save the generated token. Previously, cookies settings were set to HTTPS:
```
Cookies.set('jwt', response.data.token, {
        secure: true,
        sameSite: 'strict',
});
```

<b>Fix</b>


The code is now changed to the following to allow for HTTP instead:
```
Cookies.set('jwt', response.data.token, {
        sameSite: 'Lax',
});
```
`Lax` allows cookies via HTTP but only on same-site.

Closes #200 